### PR TITLE
GitHub handle double clone rebase

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -30,6 +30,12 @@
 <!--            <artifactId>spring-boot-starter-data-jpa</artifactId>-->
 <!--        </dependency>-->
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.23.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <scope>runtime</scope>

--- a/server/src/main/java/com/example/restdockerplatform/git/GitHubConfigurationConfig.java
+++ b/server/src/main/java/com/example/restdockerplatform/git/GitHubConfigurationConfig.java
@@ -12,14 +12,16 @@ public class GitHubConfigurationConfig {
     private final String gitHubRepositoryUrl;
     private final String gitHubUser;
     private final String gitHubToken;
-
+    private final String workDirectory;
 
     GitHubConfigurationConfig(@Value("${github.url}") String gitHubUrl,
                               @Value("${github.user}") String userName,
-                              @Value("${github.token}") String gitHubToken) {
+                              @Value("${github.token}") String gitHubToken,
+                              @Value("${user.file.space}") String workDirectory) {
         this.gitHubRepositoryUrl = gitHubUrl;
         this.gitHubUser = userName;
         this.gitHubToken = gitHubToken;
+        this.workDirectory = workDirectory;
     }
 
     String getRepositoryURI() {

--- a/server/src/main/java/com/example/restdockerplatform/git/GitHubRepositoryContentProvider.java
+++ b/server/src/main/java/com/example/restdockerplatform/git/GitHubRepositoryContentProvider.java
@@ -1,0 +1,81 @@
+package com.example.restdockerplatform.git;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.jgit.api.CloneCommand;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.eclipse.jgit.transport.CredentialsProvider;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class GitHubRepositoryContentProvider implements RepositoryContentProvider {
+
+    private final CredentialsProvider credentialsProvider;
+
+    @Override
+    public Git cloneRepository(String uri, String userId, Path path) {
+        try {
+            CloneCommand command = Git.cloneRepository()
+                    .setCredentialsProvider(credentialsProvider)
+                    .setURI(uri)
+                    .setDirectory(path.toFile());
+            if (userId != null) {
+                command.setBranch(userId);
+            }
+            return command.call();
+        } catch (GitAPIException ex) {
+            log.error("Could not clone and checkout branch {} from repository {} to location {}. Reason: {}",
+                    userId, uri, path, ex.toString());
+            throw new RuntimeException(String.format("Could not clone repository %s", uri));
+        }
+    }
+
+    @Override
+    public boolean repositoryExists(Path path) {
+        FileRepositoryBuilder repositoryBuilder = new FileRepositoryBuilder();
+        return repositoryBuilder.findGitDir(path.toFile()).getGitDir() != null;
+    }
+
+    @Override
+    public void checkoutBranch(Path path, String userId) {
+        try {
+            Git git = Git.open(path.toFile());
+            git.checkout()
+                    .setCreateBranch(true)
+                    .setName(userId)
+                    .call();
+        } catch (IOException | GitAPIException ex) {
+            log.error("Could not checkout branch {}. Reason: {}", userId, ex.toString());
+        }
+    }
+
+    @Override
+    public boolean repositoryOnBranch(String userId, Path path) {
+        try {
+            Git git = Git.open(path.toFile());
+            git.fetch().call();
+            return userId.equals(git.getRepository().getBranch());
+        } catch (GitAPIException | IOException ex) {
+            log.error("Failed to load repository in: {}. Reason: {}", path, ex.toString());
+        }
+
+        return false;
+    }
+
+    @Override
+    public void pullChanges(Path path) {
+        try {
+            Git git = Git.open(path.toFile());
+            git.pull().call();
+        } catch (IOException | GitAPIException ex) {
+            log.error("Could not pull changes to repository {}. Reason: {}", path, ex.toString());
+        }
+    }
+}

--- a/server/src/main/java/com/example/restdockerplatform/git/GitHubRepositoryUriParser.java
+++ b/server/src/main/java/com/example/restdockerplatform/git/GitHubRepositoryUriParser.java
@@ -1,0 +1,12 @@
+package com.example.restdockerplatform.git;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class GitHubRepositoryUriParser implements RepositoryUriParser {
+
+    @Override
+    public String createUri(String base, String taskId) {
+        return base + taskId + ".git";
+    }
+}

--- a/server/src/main/java/com/example/restdockerplatform/git/GitHubTaskRepository.java
+++ b/server/src/main/java/com/example/restdockerplatform/git/GitHubTaskRepository.java
@@ -2,25 +2,14 @@ package com.example.restdockerplatform.git;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.eclipse.jgit.api.AddCommand;
-import org.eclipse.jgit.api.CloneCommand;
 import org.eclipse.jgit.api.Git;
-import org.eclipse.jgit.api.Status;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.errors.RepositoryNotFoundException;
-import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.eclipse.jgit.transport.CredentialsProvider;
-import org.kohsuke.github.GHRepository;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import java.io.IOException;
-import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Component

--- a/server/src/main/java/com/example/restdockerplatform/git/GitHubTaskRepository.java
+++ b/server/src/main/java/com/example/restdockerplatform/git/GitHubTaskRepository.java
@@ -54,7 +54,7 @@ public class GitHubTaskRepository implements TaskRepository {
         }
 
         if (!repositoryContentProvider.repositoryExists(path)) {
-            repositoryContentProvider.cloneRepository(uri, null, path);
+            repositoryContentProvider.cloneRepository(uri, userId, path);
         }
         if (!repositoryContentProvider.repositoryOnBranch(userId, path)) {
             repositoryContentProvider.checkoutBranch(path, userId);

--- a/server/src/main/java/com/example/restdockerplatform/git/GitHubTaskRepository.java
+++ b/server/src/main/java/com/example/restdockerplatform/git/GitHubTaskRepository.java
@@ -7,6 +7,7 @@ import org.eclipse.jgit.api.CloneCommand;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.Status;
 import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.errors.RepositoryNotFoundException;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.eclipse.jgit.transport.CredentialsProvider;
 import org.kohsuke.github.GHRepository;
@@ -43,7 +44,7 @@ public class GitHubTaskRepository implements TaskRepository {
     }
 
     @Override
-    public void getTask(String userId, String taskId) {
+    public void getTask(String userId, String taskId) throws RepositoryNotFoundException {
         var uri = repositoryUriParser.createUri(configurationConfig.getRepositoryURI(), taskId);
         var path = Paths.get(configurationConfig.getWorkDirectory(), userId, taskId);
 
@@ -63,7 +64,7 @@ public class GitHubTaskRepository implements TaskRepository {
     }
 
     @Override
-    public void assignTaskToUser(String userId, String taskId) {
+    public void assignTaskToUser(String userId, String taskId) throws RepositoryNotFoundException {
         var uri = repositoryUriParser.createUri(configurationConfig.getRepositoryURI(), taskId);
         var path = Paths.get(configurationConfig.getWorkDirectory(), userId, taskId);
 
@@ -84,7 +85,7 @@ public class GitHubTaskRepository implements TaskRepository {
     }
 
     @Override
-    public void saveTask(String userId, String taskId) {
+    public void saveTask(String userId, String taskId) throws RepositoryNotFoundException {
         var path = Paths.get(configurationConfig.getWorkDirectory(), userId, taskId);
 
         if (repositoryContentProvider.addModifiedFiles(path) == 0) {

--- a/server/src/main/java/com/example/restdockerplatform/git/GitHubTaskRepository.java
+++ b/server/src/main/java/com/example/restdockerplatform/git/GitHubTaskRepository.java
@@ -43,9 +43,9 @@ public class GitHubTaskRepository implements TaskRepository {
     }
 
     @Override
-    public void getTask(String userId, String taskId, String workDir) {
+    public void getTask(String userId, String taskId) {
         var uri = repositoryUriParser.createUri(configurationConfig.getRepositoryURI(), taskId);
-        var path = Paths.get(workDir, userId, taskId);
+        var path = Paths.get(configurationConfig.getWorkDirectory(), userId, taskId);
 
         if (!listUserTasks(userId).contains(taskId)) {
             log.info("Task {} not assigned to user {}", taskId, userId);
@@ -63,19 +63,9 @@ public class GitHubTaskRepository implements TaskRepository {
     }
 
     @Override
-    public void getTask(String userId, String taskId) {
-        getTask(userId, taskId, configurationConfig.getWorkDirectory());
-    }
-
-    @Override
-    public void createTask(String taskName, String dir) {
-        // TO BE REMOVED
-    }
-
-    @Override
-    public void assignTaskToUser(String userId, String taskId, String workDir) {
+    public void assignTaskToUser(String userId, String taskId) {
         var uri = repositoryUriParser.createUri(configurationConfig.getRepositoryURI(), taskId);
-        var path = Paths.get(workDir, userId, taskId);
+        var path = Paths.get(configurationConfig.getWorkDirectory(), userId, taskId);
 
         if (listUserTasks(userId).contains(taskId)) {
             log.info("Task {} already assigned to user {}", taskId, userId);
@@ -94,8 +84,8 @@ public class GitHubTaskRepository implements TaskRepository {
     }
 
     @Override
-    public void saveTask(String userId, String taskId, String workDir) throws RepositoryNotFoundException {
-        var path = Paths.get(workDir, userId, taskId);
+    public void saveTask(String userId, String taskId) {
+        var path = Paths.get(configurationConfig.getWorkDirectory(), userId, taskId);
 
         if (repositoryContentProvider.addModifiedFiles(path) == 0) {
             log.info("No files modified in repo {}", path);
@@ -103,10 +93,5 @@ public class GitHubTaskRepository implements TaskRepository {
         }
         repositoryContentProvider.commit(path);
         repositoryContentProvider.push(path);
-    }
-
-
-    public void saveTask(String userId, String taskId) {
-        saveTask(userId, taskId, configurationConfig.getWorkDirectory());
     }
 }

--- a/server/src/main/java/com/example/restdockerplatform/git/GitHubUser.java
+++ b/server/src/main/java/com/example/restdockerplatform/git/GitHubUser.java
@@ -1,15 +1,19 @@
 package com.example.restdockerplatform.git;
 
 import lombok.extern.slf4j.Slf4j;
+import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GHUser;
 import org.kohsuke.github.GitHub;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Component
 @Slf4j
-public class GitHubUser {
+public class GitHubUser implements ProjectContentProvider {
     private final GitHub gitHub;
     private final GHUser gitHubUser;
 
@@ -26,5 +30,42 @@ public class GitHubUser {
 
     GHUser getGitHubUser() {
         return gitHubUser;
+    }
+
+    @Override
+    public List<String> listTasks() {
+        log.info("Listing all tasks available");
+        var repositories = gitHubUser.listRepositories();
+        try {
+            return repositories
+                    .toList()
+                    .stream()
+                    .map(GHRepository::getName)
+                    .collect(Collectors.toList());
+        } catch (IOException ex) {
+            log.error("Could not list tasks available in repository: {}", ex.toString());
+            return new ArrayList<>();
+        }
+    }
+
+    @Override
+    public List<String> listUserTasks(String userId) {
+        log.info("Listing all tasks available for user {}", userId);
+
+        List<String> branches = new ArrayList<>();
+
+        var repositories = gitHubUser.listRepositories().iterator();
+        while (repositories.hasNext()) {
+            try {
+                var repository = repositories.next();
+                if (repository.getBranches().containsKey(userId)) {
+                    branches.add(repository.getName());
+                }
+            } catch (IOException ex) {
+                log.error(String.format("Error while listing task for user: %s", ex.getMessage()));
+            }
+        }
+
+        return branches;
     }
 }

--- a/server/src/main/java/com/example/restdockerplatform/git/ProjectContentProvider.java
+++ b/server/src/main/java/com/example/restdockerplatform/git/ProjectContentProvider.java
@@ -1,0 +1,8 @@
+package com.example.restdockerplatform.git;
+
+import java.util.List;
+
+public interface ProjectContentProvider {
+    List<String> listTasks();
+    List<String> listUserTasks(String userId);
+}

--- a/server/src/main/java/com/example/restdockerplatform/git/RepositoryContentProvider.java
+++ b/server/src/main/java/com/example/restdockerplatform/git/RepositoryContentProvider.java
@@ -1,0 +1,13 @@
+package com.example.restdockerplatform.git;
+
+import org.eclipse.jgit.api.Git;
+
+import java.nio.file.Path;
+
+public interface RepositoryContentProvider {
+    Git cloneRepository(String uri, String userId, Path path);
+    boolean repositoryExists(Path path);
+    void checkoutBranch(Path path, String userId);
+    boolean repositoryOnBranch(String userId, Path path);
+    void pullChanges(Path path);
+}

--- a/server/src/main/java/com/example/restdockerplatform/git/RepositoryContentProvider.java
+++ b/server/src/main/java/com/example/restdockerplatform/git/RepositoryContentProvider.java
@@ -10,4 +10,7 @@ public interface RepositoryContentProvider {
     void checkoutBranch(Path path, String userId);
     boolean repositoryOnBranch(String userId, Path path);
     void pullChanges(Path path);
+    int addModifiedFiles(Path path);
+    void commit(Path path);
+    void push(Path path);
 }

--- a/server/src/main/java/com/example/restdockerplatform/git/RepositoryContentProvider.java
+++ b/server/src/main/java/com/example/restdockerplatform/git/RepositoryContentProvider.java
@@ -1,16 +1,18 @@
 package com.example.restdockerplatform.git;
 
 import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.errors.RepositoryNotFoundException;
 
+import java.io.IOException;
 import java.nio.file.Path;
 
 public interface RepositoryContentProvider {
     Git cloneRepository(String uri, String userId, Path path);
     boolean repositoryExists(Path path);
-    void checkoutBranch(Path path, String userId);
-    boolean repositoryOnBranch(String userId, Path path);
+    void checkoutBranch(Path path, String userId) throws RepositoryNotFoundException;
+    boolean repositoryOnBranch(String userId, Path path) throws RepositoryNotFoundException;
     void pullChanges(Path path);
-    int addModifiedFiles(Path path);
-    void commit(Path path);
-    void push(Path path);
+    int addModifiedFiles(Path path) throws RepositoryNotFoundException;
+    void commit(Path path) throws RepositoryNotFoundException;
+    void push(Path path) throws RepositoryNotFoundException;
 }

--- a/server/src/main/java/com/example/restdockerplatform/git/RepositoryUriParser.java
+++ b/server/src/main/java/com/example/restdockerplatform/git/RepositoryUriParser.java
@@ -1,0 +1,5 @@
+package com.example.restdockerplatform.git;
+
+public interface RepositoryUriParser {
+    String createUri(String base, String taskId);
+}

--- a/server/src/main/java/com/example/restdockerplatform/git/TaskRepository.java
+++ b/server/src/main/java/com/example/restdockerplatform/git/TaskRepository.java
@@ -24,9 +24,9 @@ public interface TaskRepository {
         Metoda służy do tego, aby w danym repozytorium utwożyć branch o nazwie userId
         i umieścić go w repozytorium
      */
-    void assignTaskToUser(String taskId, String userId);
+    void assignTaskToUser(String taskId, String userId) throws RepositoryNotFoundException;
 
-    void getTask(String userId, String taskId);
+    void getTask(String userId, String taskId) throws RepositoryNotFoundException;
 
     /*
         Metoda służy do tego, aby umieścić danego task przypisany do użytkownika (tj branch

--- a/server/src/main/java/com/example/restdockerplatform/git/TaskRepository.java
+++ b/server/src/main/java/com/example/restdockerplatform/git/TaskRepository.java
@@ -14,12 +14,6 @@ public interface TaskRepository {
     List<String> listTasks();
 
     /*
-        Metoda służy do tego, żeby z plików w danym katalogu utwożyć repozytorium
-        i dodać je do gita
-     */
-    void createTask(String taskName, String dir);
-
-    /*
         Przypisanie taska do użytkownika odbywa się, poprzez stworzenie w projekcie brancha z id użytkownika
         Metoda służy do tego, aby wyświetlić wszystkie projekty, które zawierają branch o nazwie
         odpowiadającej id użytkownika
@@ -30,19 +24,14 @@ public interface TaskRepository {
         Metoda służy do tego, aby w danym repozytorium utwożyć branch o nazwie userId
         i umieścić go w repozytorium
      */
-    void assignTaskToUser(String taskId, String userId, String workDir);
+    void assignTaskToUser(String taskId, String userId);
 
-    /*
-        Metoda służąca do tego, aby sklonować projekt taskName i zrobić checkout brancha taskId
-     */
-    void getTask(String userId, String taskId, String workDir);
     void getTask(String userId, String taskId);
 
     /*
         Metoda służy do tego, aby umieścić danego task przypisany do użytkownika (tj branch
         o nazwie równej ID użytkownika w repozytorium zdalnym
      */
-    void saveTask(String userId, String taskId, String workDir) throws RepositoryNotFoundException;
 
     void saveTask(String userId, String taskId) throws RepositoryNotFoundException;
 }

--- a/server/src/test/java/com/example/restdockerplatform/git/GitHubTaskRepositoryTest.java
+++ b/server/src/test/java/com/example/restdockerplatform/git/GitHubTaskRepositoryTest.java
@@ -1,7 +1,11 @@
 package com.example.restdockerplatform.git;
 
-import org.eclipse.jgit.errors.RepositoryNotFoundException;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
 import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+
+import java.io.File;
 
 
 public class GitHubTaskRepositoryTest {
@@ -9,44 +13,61 @@ public class GitHubTaskRepositoryTest {
     static final String GIT_HUB_REPOSITORY_URL = "https://github.com/";
     static final String GIT_HUB_USER = "java-dev-pro-project";
     static final String GH_TOKEN = "";
-    static final GitHubConfigurationConfig  gitHubConfigurationConfig = new GitHubConfigurationConfig(GIT_HUB_REPOSITORY_URL, GIT_HUB_USER, GH_TOKEN);
+    static final GitHubConfigurationConfig  gitHubConfigurationConfig = new GitHubConfigurationConfig(
+            GIT_HUB_REPOSITORY_URL,
+            GIT_HUB_USER,
+            GH_TOKEN,
+            WORK_DIR);
     GitHubTaskRepository tr = new GitHubTaskRepository(
             gitHubConfigurationConfig,
             new GitHubCredentialsProvider(gitHubConfigurationConfig),
-            new GitHubUser(gitHubConfigurationConfig),
-            "C:\\project_workspace"
+            new GitHubUser(gitHubConfigurationConfig)
             );
 
     @Test
+    @Disabled
+    public void shouldCreateRepo() throws GitAPIException {
+        Git.cloneRepository()
+                .setURI("C:\\Users\\soker\\work\\testRepo")
+                .setDirectory(new File("C:\\Users\\soker\\work\\gitWorkDir"))
+                .setBranch("master").call().close();
+    }
+
+    @Test
+    @Disabled
     public void shouldListAllRepositories() {
         tr.listTasks().forEach(System.out::println);
     }
 
     @Test
+    @Disabled
     public void shouldListAllTasksAvailableForUser() {
         String userName = "user_jan";
         tr.listUserTasks(userName).forEach(System.out::println);
     }
 
     @Test
+    @Disabled
     public void shouldCloneUserBranchFromRepository() {
-        String userId = "user_tomasz";
+        String userId = "user_karol";
         String taskId = "task3";
 
         tr.getTask(userId, taskId, WORK_DIR);
     }
 
     @Test
+    @Disabled
     public void shouldCreateBranchForUserInTask() {
-        String userId = "user_adam";
+        String userId = "user_karol";
         String taskId = "task3";
 
         tr.assignTaskToUser(userId, taskId, WORK_DIR);
     }
 
     @Test
-    public void shouldCommitAndPushUserChangesInBranch() throws RepositoryNotFoundException {
-        String userId = "user_adam";
+    @Disabled
+    public void shouldCommitAndPushUserChangesInBranch() {
+        String userId = "user_karol";
         String taskId = "task3";
 
         tr.saveTask(userId, taskId, WORK_DIR);

--- a/server/src/test/java/com/example/restdockerplatform/git/GitHubTaskRepositoryTest.java
+++ b/server/src/test/java/com/example/restdockerplatform/git/GitHubTaskRepositoryTest.java
@@ -97,7 +97,7 @@ public class GitHubTaskRepositoryTest {
         when(helper.getProjectContentProvider().listUserTasks(anyString())).thenReturn(Collections.emptyList());
 
         // when
-        helper.getTestedTaskRepository().assignTaskToUser(userId, taskId, helper.getTargetRepositoryPath());
+        helper.getTestedTaskRepository().assignTaskToUser(userId, taskId);
 
         // then
         var remoteBranches = helper.getRemoteRepository().branchList().call()
@@ -118,7 +118,7 @@ public class GitHubTaskRepositoryTest {
         when(helper.getProjectContentProvider().listUserTasks(anyString())).thenReturn(List.of(taskId));
 
         // when
-        helper.getTestedTaskRepository().assignTaskToUser(userId, taskId, helper.getTargetRepositoryPath());
+        helper.getTestedTaskRepository().assignTaskToUser(userId, taskId);
 
         // then
         Mockito.verify(helper.getRepositoryContentProvider(), times(0))

--- a/server/src/test/java/com/example/restdockerplatform/git/GitHubTaskRepositoryTest.java
+++ b/server/src/test/java/com/example/restdockerplatform/git/GitHubTaskRepositoryTest.java
@@ -41,7 +41,7 @@ public class GitHubTaskRepositoryTest {
         Assertions.assertTrue(expectedPath.toFile().exists());
         Assertions.assertTrue(helper.getRepositoryContentProvider().repositoryOnBranch(userId, expectedPath));
         Mockito.verify(helper.getRepositoryContentProvider(), times(0))
-                .pullChanges(any());
+                .checkoutBranch(any(), any());
     }
 
     @Test
@@ -60,9 +60,9 @@ public class GitHubTaskRepositoryTest {
         // then
         Mockito.verify(helper.getRepositoryContentProvider(), times(1))
                 .cloneRepository(any(), any(), any());
-        Mockito.verify(helper.getRepositoryContentProvider(), times(1))
+        Mockito.verify(helper.getRepositoryContentProvider(), times(0))
                 .checkoutBranch(any(), any());
-        Mockito.verify(helper.getRepositoryContentProvider(), times(1))
+        Mockito.verify(helper.getRepositoryContentProvider(), times(2))
                 .pullChanges(any());
     }
 

--- a/server/src/test/java/com/example/restdockerplatform/git/GitHubTaskRepositoryTest.java
+++ b/server/src/test/java/com/example/restdockerplatform/git/GitHubTaskRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.example.restdockerplatform.git;
 
 import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.errors.RepositoryNotFoundException;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.junit.Test;
@@ -130,9 +131,9 @@ public class GitHubTaskRepositoryTest {
     @Test
     public void shouldNotCommitWhenNoChangesInRepo() throws GitAPIException, IOException {
         // given
-        var helper = GitHubTestTaskHelper.init();
         String userId = "user_karol";
         String taskId = "task3";
+        var helper = GitHubTestTaskHelper.init().withUserRepository(userId, taskId);
 
         // when
         helper.getTestedTaskRepository().saveTask(userId, taskId);
@@ -173,5 +174,16 @@ public class GitHubTaskRepositoryTest {
         }
 
         Assertions.assertEquals(2, count);
+    }
+
+    @Test
+    public void shouldThrowWhenUserRepositoryDoesNotExist() throws GitAPIException, IOException {
+        // given
+        String userId = "user_karol";
+        String taskId = "task3";
+        var helper = GitHubTestTaskHelper.init();
+
+        // when, then
+        Assertions.assertThrows(RepositoryNotFoundException.class, () -> { helper.getTestedTaskRepository().saveTask(userId, taskId); });
     }
 }

--- a/server/src/test/java/com/example/restdockerplatform/git/GitHubTestTaskHelper.java
+++ b/server/src/test/java/com/example/restdockerplatform/git/GitHubTestTaskHelper.java
@@ -22,11 +22,11 @@ public class GitHubTestTaskHelper {
     static private final String DUMMY_FILE_NAME = "Readme.md";
     static private final String DUMMY_FILE_CONTENT = "CONTENT";
     static private final String DUMMY_COMMIT_MESSAGE = "Init Commit";
-
     static private final String TOKEN = "admin";
 
     String tempDirectory;
     String targetRepositoryPath;
+    Path sourceDirectoryPath;
     Git remoteRepository;
     TaskRepository testedTaskRepository;
 
@@ -34,7 +34,6 @@ public class GitHubTestTaskHelper {
     RepositoryContentProvider repositoryContentProvider;
 
     private GitHubTestTaskHelper() {
-
     }
 
     static GitHubTestTaskHelper init() throws GitAPIException, IOException {
@@ -56,15 +55,30 @@ public class GitHubTestTaskHelper {
         return this;
     }
 
+    public GitHubTestTaskHelper withUserRepository(String userId, String taskId) {
+        testedTaskRepository.assignTaskToUser(userId, taskId, targetRepositoryPath);
+        return this;
+    }
+
+    public GitHubTestTaskHelper withUserFileModified(String userId, String taskId) throws IOException {
+        try (PrintWriter writer = new PrintWriter(
+                Paths.get(targetRepositoryPath, userId, taskId, DUMMY_FILE_NAME).toString(),
+                StandardCharsets.UTF_8)) {
+            writer.append("aa");
+        }
+
+        return this;
+    }
+
     private void setupRemoteRepository() throws IOException, GitAPIException {
         tempDirectory = Files.createTempDirectory(TEMP_DIRECTORY_PREFIX).toFile().getAbsolutePath();
 
-        Path sourceDirectoryPath = Paths.get(tempDirectory, SOURCE_REPOSITORY_DIRECTORY_NAME);
+        sourceDirectoryPath = Paths.get(tempDirectory, SOURCE_REPOSITORY_DIRECTORY_NAME);
 
         Files.createDirectory(sourceDirectoryPath);
         remoteRepository = Git.init().setDirectory(sourceDirectoryPath.toFile()).call();
 
-        try (PrintWriter writer = new PrintWriter(Paths.get(sourceDirectoryPath.toString(),DUMMY_FILE_NAME).toString(), StandardCharsets.UTF_8)) {
+        try (PrintWriter writer = new PrintWriter(Paths.get(sourceDirectoryPath.toString(), DUMMY_FILE_NAME).toString(), StandardCharsets.UTF_8)) {
             writer.println(DUMMY_FILE_CONTENT);
         }
 
@@ -87,7 +101,6 @@ public class GitHubTestTaskHelper {
 
         projectContentProvider = mock(ProjectContentProvider.class);
         repositoryContentProvider = spy(new GitHubRepositoryContentProvider(credentialsProvider));
-
 
         testedTaskRepository = new GitHubTaskRepository(
                 gitHubConfigurationConfig,

--- a/server/src/test/java/com/example/restdockerplatform/git/GitHubTestTaskHelper.java
+++ b/server/src/test/java/com/example/restdockerplatform/git/GitHubTestTaskHelper.java
@@ -56,7 +56,7 @@ public class GitHubTestTaskHelper {
     }
 
     public GitHubTestTaskHelper withUserRepository(String userId, String taskId) {
-        testedTaskRepository.assignTaskToUser(userId, taskId, targetRepositoryPath);
+        testedTaskRepository.assignTaskToUser(userId, taskId);
         return this;
     }
 

--- a/server/src/test/java/com/example/restdockerplatform/git/GitHubTestTaskHelper.java
+++ b/server/src/test/java/com/example/restdockerplatform/git/GitHubTestTaskHelper.java
@@ -3,6 +3,7 @@ package com.example.restdockerplatform.git;
 import lombok.Getter;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.errors.RepositoryNotFoundException;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -55,7 +56,7 @@ public class GitHubTestTaskHelper {
         return this;
     }
 
-    public GitHubTestTaskHelper withUserRepository(String userId, String taskId) {
+    public GitHubTestTaskHelper withUserRepository(String userId, String taskId) throws RepositoryNotFoundException {
         testedTaskRepository.assignTaskToUser(userId, taskId);
         return this;
     }

--- a/server/src/test/java/com/example/restdockerplatform/git/GitHubTestTaskHelper.java
+++ b/server/src/test/java/com/example/restdockerplatform/git/GitHubTestTaskHelper.java
@@ -1,0 +1,101 @@
+package com.example.restdockerplatform.git;
+
+import lombok.Getter;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+@Getter
+public class GitHubTestTaskHelper {
+    static private final String TEMP_DIRECTORY_PREFIX = "repo_test_";
+    static private final String SOURCE_REPOSITORY_DIRECTORY_NAME = "source_repo";
+    static private final String TARGET_REPOSITORY_DIRECTORY_NAME = "target_repo";
+    static private final String DUMMY_FILE_NAME = "Readme.md";
+    static private final String DUMMY_FILE_CONTENT = "CONTENT";
+    static private final String DUMMY_COMMIT_MESSAGE = "Init Commit";
+
+    static private final String TOKEN = "admin";
+
+    String tempDirectory;
+    String targetRepositoryPath;
+    Git remoteRepository;
+    TaskRepository testedTaskRepository;
+
+    ProjectContentProvider projectContentProvider;
+    RepositoryContentProvider repositoryContentProvider;
+
+    private GitHubTestTaskHelper() {
+
+    }
+
+    static GitHubTestTaskHelper init() throws GitAPIException, IOException {
+        GitHubTestTaskHelper tr = new GitHubTestTaskHelper();
+
+        tr.setupRemoteRepository();
+        tr.setupTargetRepository();
+        tr.setupTestedTaskRepository();
+
+        return tr;
+    }
+
+    public GitHubTestTaskHelper withBranchForUser(String userId) throws GitAPIException {
+        remoteRepository
+                .checkout()
+                .setCreateBranch(true)
+                .setName(userId).call();
+
+        return this;
+    }
+
+    private void setupRemoteRepository() throws IOException, GitAPIException {
+        tempDirectory = Files.createTempDirectory(TEMP_DIRECTORY_PREFIX).toFile().getAbsolutePath();
+
+        Path sourceDirectoryPath = Paths.get(tempDirectory, SOURCE_REPOSITORY_DIRECTORY_NAME);
+
+        Files.createDirectory(sourceDirectoryPath);
+        remoteRepository = Git.init().setDirectory(sourceDirectoryPath.toFile()).call();
+
+        try (PrintWriter writer = new PrintWriter(Paths.get(sourceDirectoryPath.toString(),DUMMY_FILE_NAME).toString(), StandardCharsets.UTF_8)) {
+            writer.println(DUMMY_FILE_CONTENT);
+        }
+
+        remoteRepository.add().addFilepattern(".").call();
+        remoteRepository.commit().setMessage(DUMMY_COMMIT_MESSAGE).call();
+    }
+
+    private void setupTargetRepository() {
+        targetRepositoryPath = Paths.get(tempDirectory, TARGET_REPOSITORY_DIRECTORY_NAME).toString();
+    }
+
+    private void setupTestedTaskRepository() {
+        GitHubConfigurationConfig  gitHubConfigurationConfig = new GitHubConfigurationConfig(
+                tempDirectory,
+                SOURCE_REPOSITORY_DIRECTORY_NAME,
+                TOKEN,
+                targetRepositoryPath);
+
+        var credentialsProvider = new GitHubCredentialsProvider(gitHubConfigurationConfig);
+
+        projectContentProvider = mock(ProjectContentProvider.class);
+        repositoryContentProvider = spy(new GitHubRepositoryContentProvider(credentialsProvider));
+
+
+        testedTaskRepository = new GitHubTaskRepository(
+                gitHubConfigurationConfig,
+                new GitHubCredentialsProvider(gitHubConfigurationConfig),
+                projectContentProvider,
+                repositoryContentProvider,
+                new LocalRepositoryUriParser()
+        );
+
+    }
+}

--- a/server/src/test/java/com/example/restdockerplatform/git/LocalRepositoryUriParser.java
+++ b/server/src/test/java/com/example/restdockerplatform/git/LocalRepositoryUriParser.java
@@ -1,0 +1,8 @@
+package com.example.restdockerplatform.git;
+
+public class LocalRepositoryUriParser implements RepositoryUriParser {
+    @Override
+    public String createUri(String base, String taskId) {
+        return base + ".git";
+    }
+}


### PR DESCRIPTION
- zmieniona została implementacja: sprawdzanie przypadku podwójnego clone, dodany wyjątek informujący o nieistnieniu repo, kod testowalny

- dodane testy integracyjne
